### PR TITLE
Stream assistant responses and simplify image handling

### DIFF
--- a/src/utils/vector_search.py
+++ b/src/utils/vector_search.py
@@ -228,7 +228,7 @@ def perform_vector_search(query: str, vector_search_fields: List[str]) -> Dict[s
 
     return {
         "vector_search_results": vector_search_results,
-        "vector_serach_full_results": schema,
+        "vector_search_full_results": schema,
         "split_queries": split_queries,
         "cmip6_args": DynamicCMIP6DownloadArgs
     }


### PR DESCRIPTION
## Summary
- add `parse_image_markdown` helper in `chat_utils`
- use helper to show past chat messages with optional figures
- stream LLM output live in `handle_user_input`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
