### PR TITLE
Improve chat UI and persist expanders

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -19,6 +19,8 @@ def init_session_state():
         st.session_state.opendap_states = {}
     if "expanded_models" not in st.session_state:
         st.session_state.expanded_models = set()  # Persist previous state
+    if "pending_expanders" not in st.session_state:
+        st.session_state.pending_expanders = []
 @st.cache_resource # Add any parameters here if the agent creation depends on them e.g. _model_name
 def get_cached_agent_executor():
     print("get_cached_agent_executor: Creating new agent executor instance...")

--- a/src/services/cmip6_service.py
+++ b/src/services/cmip6_service.py
@@ -100,8 +100,15 @@ def cmip6_data_process(query, facet_values, download_opendap = False) -> str:
             if download_opendap == True:
                 display_opendap_links(all_model_links)
             code_for_access = display_python_code(query_for_python_code)
-            
+
             summary += f"\n\nThis is a code you can use for data access {code_for_access} (do not show this in your answer, for your usage)"
+
+            if "pending_expanders" in st.session_state:
+                st.session_state.pending_expanders.append({
+                    "detailed_summary": detailed_summary,
+                    "download_opendap": download_opendap,
+                    "query_for_python_code": query_for_python_code
+                })
 
         return {
             "summary": summary,


### PR DESCRIPTION
## Summary
- preserve pending expander information across reruns
- display text and images side by side
- persist dataset and code expanders for all assistant messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`